### PR TITLE
feat: truncate hash to 6 digits in table view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "modsurfer-cli"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "clap 4.1.4",

--- a/cli/src/cmd/api_result.rs
+++ b/cli/src/cmd/api_result.rs
@@ -72,7 +72,7 @@ impl Display for ApiResults<'_> {
         self.results.iter().for_each(|m| {
             table.add_row(Row::from(vec![
                 m.module_id.to_string(),
-                m.hash.clone(),
+                m.hash[0..6].to_string(),
                 m.file_name.clone(),
                 m.exports.to_string(),
                 m.imports.to_string(),

--- a/vendors/wasmcloud/mod.yaml
+++ b/vendors/wasmcloud/mod.yaml
@@ -38,6 +38,6 @@ validate:
       - I32
     max: 2
   size:
-    max: 1.9 MiB
+    max: 10 MiB
   complexity:
     max_risk: medium


### PR DESCRIPTION
Hash column took up too much horizontal space, now the table fits a more narrow terminal. 

```
┌─────────────────────┬────────┬─────────────────┬───────────┬───────────┬────────────────────────┬─────────┬───────────┐
│ ID                  │ Hash   │ Filename        │ # Exports │ # Imports │ Namespaces             │ Source  │ Size      │
╞═════════════════════╪════════╪═════════════════╪═══════════╪═══════════╪════════════════════════╪═════════╪═══════════╡
│ 3491933836965728984 │ 55414f │ advent.wasm     │ 1         │ 5         │ wasi_snapshot_preview1 │ Unknown │ 121.1 KiB │
├─────────────────────┼────────┼─────────────────┼───────────┼───────────┼────────────────────────┼─────────┼───────────┤
│ 3491933839433176491 │ 22dd5d │ base64-cli.wasm │ 5         │ 8         │ wasi_snapshot_preview1 │ Rust    │ 2.4 MiB   │
├─────────────────────┼────────┼─────────────────┼───────────┼───────────┼────────────────────────┼─────────┼───────────┤
│ 3491933840755152073 │ a8fcad │ chkfont.wasm    │ 1         │ 12        │ wasi_snapshot_preview1 │ C       │ 73.9 KiB  │
└─────────────────────┴────────┴─────────────────┴───────────┴───────────┴────────────────────────┴─────────┴───────────┘

```

you can get the full hash by using `--output-format json`:

```json
{
  "results": [
    {
      "module_id": 3491933836965728984,
      "hash": "55414f8c569b37bf71a353c33f5695172a80ca00648cf32408a26fcf46b49070",
      "file_name": "advent.wasm",
      "exports": 1,
      "imports": 5,
      "namespaces": [
        "wasi_snapshot_preview1"
      ],
      "source_language": "Unknown",
      "size": "121.1 KiB"
    },
    {
      "module_id": 3491933839433176491,
      "hash": "22dd5d48e40959c8fa25f5968aaf3d5af9430e848d9a582b7a0b6ba2aaf9a438",
      "file_name": "base64-cli.wasm",
      "exports": 5,
      "imports": 8,
      "namespaces": [
        "wasi_snapshot_preview1"
      ],
      "source_language": "Rust",
      "size": "2.4 MiB"
    },
    {
      "module_id": 3491933840755152073,
      "hash": "a8fcad775e5ab5739c3d6f723cc8121b56fea9c1078d2b1bb1c2e0216d599062",
      "file_name": "chkfont.wasm",
      "exports": 1,
      "imports": 12,
      "namespaces": [
        "wasi_snapshot_preview1"
      ],
      "source_language": "C",
      "size": "73.9 KiB"
    }
  ]
}

```