### PR TITLE
Typo fix for module

### DIFF
--- a/cli/src/cmd/exec.rs
+++ b/cli/src/cmd/exec.rs
@@ -369,7 +369,7 @@ impl<'a> From<(&'a str, &'a clap::ArgMatches)> for Subcommand<'a> {
                 output_format(args),
             ),
             ("get", args) => Subcommand::Get(
-                *args.get_one("id").expect("valid moudle ID"),
+                *args.get_one("id").expect("valid module ID"),
                 output_format(args),
             ),
             ("list", args) => Subcommand::List(


### PR DESCRIPTION
fix typo 

@nilslice I also wanted to try to fix the issue reported in the issue #28 but couldn't find the code base for the application, is it part of this codebase?