### PR TITLE
ci: pass invalid module check

### DIFF
--- a/.github/workflows/ci-action-test.yml
+++ b/.github/workflows/ci-action-test.yml
@@ -12,6 +12,9 @@ jobs:
         with:
             path: test/spidermonkey.wasm
             check: test/mod.yaml
-      - name: check failure
+      - name: check failure (expected)
         if: job.steps.validate-should-fail.status == failure()
         run: exit 0
+      - name: check success (unexpected)
+        if: job.steps.validate-should-fail.status == success()
+        run: exit 1

--- a/.github/workflows/ci-action-test.yml
+++ b/.github/workflows/ci-action-test.yml
@@ -6,7 +6,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: modsurfer validate
+        id: validate-should-fail
+        continue-on-error: true
         uses: dylibso/modsurfer-validate-action@main
         with:
             path: test/spidermonkey.wasm
             check: test/mod.yaml
+      - name: check failure
+        if: job.steps.validate-should-fail.status == failure()
+        run: exit 0


### PR DESCRIPTION
This simply checks that a validation action in CI _fails_ and then allows the action to pass successfully. Before this PR, we'd see a failing check (which is expected), but now this interprets that expected failure as a successful test. 