### PR TITLE
release: v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "modsurfer-cli"
-version = "0.0.6"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "clap 4.2.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modsurfer-cli"
-version = "0.0.6"
+version = "0.0.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,6 +28,8 @@ Commands:
            Return a list of modules which violate requirements in the provided checkfile.
   generate
           Generate a starter checkfile from the given module.
+  diff
+          Compare two modules
   help
           Print this message or the help of the given subcommand(s)
 
@@ -57,9 +59,9 @@ modsurfer get --id 4 | jq . | ...
 
 modsurfer create \
         -p my.wasm \
-        -c mod.yaml \
+        -c mod.yaml \ # optional - validate before creating an entry in Modsurfer
         -l file:///wasm/my.wasm \
-        -m userid=12234 -m app=33
+        -m userid=12234 -m app=33 # optional - associate searchable key-value metadata with a module
 
 modsurfer delete --id 3 --id 4 --id 5
 
@@ -70,6 +72,8 @@ modsurfer list --offset 0 --limit 50 # (0 & 50 are defaults)
 modsurfer search --function-name _start --module-name env --source-language Rust --text "Help me"
 
 modsurfer generare -p spidermonkey.wasm -o mod.yaml
+
+modsurfer diff a.wasm b.wasm # or diff using Modsurfer module IDs
 
 modsurfer audit --outcome pass -c mod.yaml
 ```

--- a/convert/src/lib.rs
+++ b/convert/src/lib.rs
@@ -2,7 +2,6 @@ mod types;
 
 pub use types::{Order, Pagination, Sort, SortField};
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "api")]
 pub use types::{Audit, AuditOutcome, Search};
 

--- a/convert/src/types.rs
+++ b/convert/src/types.rs
@@ -1,8 +1,7 @@
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "api")]
 use chrono::Utc;
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
+
 use modsurfer_module::{Export, Import, SourceLanguage};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,7 +52,6 @@ pub struct Sort {
     pub field: SortField,
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "api")]
 #[derive(Default)]
 pub struct Search {
@@ -65,22 +63,24 @@ pub struct Search {
     pub function_name: Option<String>,
     pub module_name: Option<String>,
     pub source_language: Option<SourceLanguage>,
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub inserted_after: Option<chrono::DateTime<Utc>>,
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub inserted_after: Option<u64>,
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub inserted_before: Option<chrono::DateTime<Utc>>,
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub inserted_before: Option<u64>,
     pub strings: Option<Vec<String>>,
     pub sort: Option<Sort>,
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 #[derive(Debug, Clone)]
 pub enum AuditOutcome {
     Pass,
     Fail,
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl std::fmt::Display for AuditOutcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -90,16 +90,12 @@ impl std::fmt::Display for AuditOutcome {
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl From<&std::ffi::OsStr> for AuditOutcome {
     fn from(value: &std::ffi::OsStr) -> Self {
         value.to_str().unwrap_or_else(|| "fail").to_string().into()
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl From<String> for AuditOutcome {
     fn from(value: String) -> Self {
         match value.to_lowercase().as_str() {
@@ -109,8 +105,6 @@ impl From<String> for AuditOutcome {
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 #[derive(Debug)]
 pub struct Audit {
     pub page: Pagination,
@@ -118,16 +112,12 @@ pub struct Audit {
     pub checkfile: Vec<u8>,
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl Default for AuditOutcome {
     fn default() -> Self {
         AuditOutcome::Fail
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl From<modsurfer_proto_v1::api::AuditOutcome> for AuditOutcome {
     fn from(outcome: modsurfer_proto_v1::api::AuditOutcome) -> AuditOutcome {
         match outcome {
@@ -137,8 +127,6 @@ impl From<modsurfer_proto_v1::api::AuditOutcome> for AuditOutcome {
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "api")]
 impl From<AuditOutcome> for modsurfer_proto_v1::api::AuditOutcome {
     fn from(outcome: AuditOutcome) -> Self {
         match outcome {


### PR DESCRIPTION
# v0.0.8:

## Add command to `diff` two modules 

Outputs raw diff format (Markdown-flavored) showing the properties changed from `module1` to `module2`. 

### `modsurfer diff <module1> <module2>`

```diff
# modsurfer diff a.wasm b.wasm # (or, using module IDs from Modsurfer API: modsurfer diff 3491933839433176491 3491933840755152073)
-   - name: run
+   - name: run_updated
-   max: 4.8 MiB
+   max: 33.1 MiB
```


```diff
# modsurfer diff a.wasm b.wasm --with-context # (retains the unchanged contents between the two modules)
    imports:
    include:
    - namespace: env
      name: extism_error_set
      params:
      - I64
      results: []
    - namespace: env
      name: extism_alloc
      params:
      - I64
      results:
      - I64
    - namespace: env
      name: extism_output_set
      params:
      - I64
      - I64
      results: []
    - namespace: env
      name: extism_free
      params:
      - I64
      results: []
    - namespace: env
      name: extism_input_length
      params: []
      results:
      - I64
    - namespace: env
      name: extism_input_load_u64
      params:
      - I64
      results:
      - I64
    - namespace: env
      name: extism_input_load_u8
      params:
      - I64
      results:
      - I32
    - namespace: env
      name: extism_store_u8
      params:
      - I64
      - I32
      results: []
    - namespace: env
      name: extism_store_u64
      params:
      - I64
      - I64
      results: []
    namespace:
      include:
      - env
  exports:
    include:
-   - name: run
+   - name: run_updated
      params: []
      results:
      - I32
    max: 1
  size:
-   max: 4.8 MiB
+   max: 33.1 MiB
  complexity:
    max_risk: low
```

```