### PR TITLE
fix: rename `args` to `params` and `returns` to `results`

### DIFF
--- a/convert/src/from_api.rs
+++ b/convert/src/from_api.rs
@@ -61,8 +61,8 @@ pub fn import(import: api::Import) -> Import {
         func: Function {
             name,
             ty: FunctionType {
-                args: val_types(f.args),
-                returns: val_types(f.returns),
+                params: val_types(f.params),
+                results: val_types(f.results),
             },
         },
     }
@@ -79,8 +79,8 @@ pub fn export(export: api::Export) -> Export {
         func: Function {
             name,
             ty: FunctionType {
-                args: val_types(f.args),
-                returns: val_types(f.returns),
+                params: val_types(f.params),
+                results: val_types(f.results),
             },
         },
     }

--- a/convert/src/to_api.rs
+++ b/convert/src/to_api.rs
@@ -78,8 +78,8 @@ pub fn exports(exports: Vec<Export>) -> Vec<api::Export> {
         .map(|e| {
             let func = api::Function {
                 name: e.func.name,
-                args: to_api::val_types(e.func.ty.args),
-                returns: to_api::val_types(e.func.ty.returns),
+                params: to_api::val_types(e.func.ty.params),
+                results: to_api::val_types(e.func.ty.results),
                 ..Default::default()
             };
 
@@ -97,8 +97,8 @@ pub fn imports(imports: Vec<Import>) -> Vec<api::Import> {
         .map(|i| {
             let func = api::Function {
                 name: i.func.name,
-                args: to_api::val_types(i.func.ty.args),
-                returns: to_api::val_types(i.func.ty.returns),
+                params: to_api::val_types(i.func.ty.params),
+                results: to_api::val_types(i.func.ty.results),
                 ..Default::default()
             };
 

--- a/module/src/function.rs
+++ b/module/src/function.rs
@@ -6,8 +6,8 @@ pub struct Function {
 
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FunctionType {
-    pub args: Vec<ValType>,
-    pub returns: Vec<ValType>,
+    pub params: Vec<ValType>,
+    pub results: Vec<ValType>,
 }
 
 /// Represents the types of values in a WebAssembly module.
@@ -73,8 +73,8 @@ impl From<ValType> for wasmparser::ValType {
 impl<'a> From<&'a wasmparser::FuncType> for FunctionType {
     fn from(ft: &'a wasmparser::FuncType) -> Self {
         Self {
-            args: ft.params().iter().cloned().map(ValType::from).collect(),
-            returns: ft.results().iter().cloned().map(ValType::from).collect(),
+            params: ft.params().iter().cloned().map(ValType::from).collect(),
+            results: ft.results().iter().cloned().map(ValType::from).collect(),
         }
     }
 }

--- a/proto/v1/api.proto
+++ b/proto/v1/api.proto
@@ -16,8 +16,8 @@ enum ValType {
 
 // Contained by an import or export element within a wasm binary.
 message Function {
-  repeated ValType args = 1;
-  repeated ValType returns = 2;
+  repeated ValType params = 1;
+  repeated ValType results = 2;
   string name = 3;
 }
 

--- a/proto/v1/src/api.rs
+++ b/proto/v1/src/api.rs
@@ -30,10 +30,10 @@ const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_3_2_0;
 // @@protoc_insertion_point(message:Function)
 pub struct Function {
     // message fields
-    // @@protoc_insertion_point(field:Function.args)
-    pub args: ::std::vec::Vec<::protobuf::EnumOrUnknown<ValType>>,
-    // @@protoc_insertion_point(field:Function.returns)
-    pub returns: ::std::vec::Vec<::protobuf::EnumOrUnknown<ValType>>,
+    // @@protoc_insertion_point(field:Function.params)
+    pub params: ::std::vec::Vec<::protobuf::EnumOrUnknown<ValType>>,
+    // @@protoc_insertion_point(field:Function.results)
+    pub results: ::std::vec::Vec<::protobuf::EnumOrUnknown<ValType>>,
     // @@protoc_insertion_point(field:Function.name)
     pub name: ::std::string::String,
     // special fields
@@ -56,14 +56,14 @@ impl Function {
         let mut fields = ::std::vec::Vec::with_capacity(3);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
-            "args",
-            |m: &Function| { &m.args },
-            |m: &mut Function| { &mut m.args },
+            "params",
+            |m: &Function| { &m.params },
+            |m: &mut Function| { &mut m.params },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
-            "returns",
-            |m: &Function| { &m.returns },
-            |m: &mut Function| { &mut m.returns },
+            "results",
+            |m: &Function| { &m.results },
+            |m: &mut Function| { &mut m.results },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "name",
@@ -89,16 +89,16 @@ impl ::protobuf::Message for Function {
         while let Some(tag) = is.read_raw_tag_or_eof()? {
             match tag {
                 8 => {
-                    self.args.push(is.read_enum_or_unknown()?);
+                    self.params.push(is.read_enum_or_unknown()?);
                 },
                 10 => {
-                    ::protobuf::rt::read_repeated_packed_enum_or_unknown_into(is, &mut self.args)?
+                    ::protobuf::rt::read_repeated_packed_enum_or_unknown_into(is, &mut self.params)?
                 },
                 16 => {
-                    self.returns.push(is.read_enum_or_unknown()?);
+                    self.results.push(is.read_enum_or_unknown()?);
                 },
                 18 => {
-                    ::protobuf::rt::read_repeated_packed_enum_or_unknown_into(is, &mut self.returns)?
+                    ::protobuf::rt::read_repeated_packed_enum_or_unknown_into(is, &mut self.results)?
                 },
                 26 => {
                     self.name = is.read_string()?;
@@ -115,10 +115,10 @@ impl ::protobuf::Message for Function {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u64 {
         let mut my_size = 0;
-        for value in &self.args {
+        for value in &self.params {
             my_size += ::protobuf::rt::int32_size(1, value.value());
         };
-        for value in &self.returns {
+        for value in &self.results {
             my_size += ::protobuf::rt::int32_size(2, value.value());
         };
         if !self.name.is_empty() {
@@ -130,10 +130,10 @@ impl ::protobuf::Message for Function {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        for v in &self.args {
+        for v in &self.params {
             os.write_enum(1, ::protobuf::EnumOrUnknown::value(v))?;
         };
-        for v in &self.returns {
+        for v in &self.results {
             os.write_enum(2, ::protobuf::EnumOrUnknown::value(v))?;
         };
         if !self.name.is_empty() {
@@ -156,16 +156,16 @@ impl ::protobuf::Message for Function {
     }
 
     fn clear(&mut self) {
-        self.args.clear();
-        self.returns.clear();
+        self.params.clear();
+        self.results.clear();
         self.name.clear();
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static Function {
         static instance: Function = Function {
-            args: ::std::vec::Vec::new(),
-            returns: ::std::vec::Vec::new(),
+            params: ::std::vec::Vec::new(),
+            results: ::std::vec::Vec::new(),
             name: ::std::string::String::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
@@ -4107,9 +4107,9 @@ impl AuditOutcome {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x12proto/v1/api.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"`\n\x08\
-    Function\x12\x1c\n\x04args\x18\x01\x20\x03(\x0e2\x08.ValTypeR\x04args\
-    \x12\"\n\x07returns\x18\x02\x20\x03(\x0e2\x08.ValTypeR\x07returns\x12\
+    \n\x12proto/v1/api.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"d\n\x08\
+    Function\x12\x20\n\x06params\x18\x01\x20\x03(\x0e2\x08.ValTypeR\x06param\
+    s\x12\"\n\x07results\x18\x02\x20\x03(\x0e2\x08.ValTypeR\x07results\x12\
     \x12\n\x04name\x18\x03\x20\x01(\tR\x04name\"H\n\x06Import\x12\x1f\n\x0bm\
     odule_name\x18\x01\x20\x01(\tR\nmoduleName\x12\x1d\n\x04func\x18\x02\x20\
     \x01(\x0b2\t.FunctionR\x04func\"'\n\x06Export\x12\x1d\n\x04func\x18\x01\
@@ -4233,9 +4233,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x03\r\x0e\x0f\nL\n\x02\x04\0\x12\x04\x11\0\x15\x01\x1a@\x20Contained\
     \x20by\x20an\x20import\x20or\x20export\x20element\x20within\x20a\x20wasm\
     \x20binary.\n\n\n\n\x03\x04\0\x01\x12\x03\x11\x08\x10\n\x0b\n\x04\x04\0\
-    \x02\0\x12\x03\x12\x02\x1c\n\x0c\n\x05\x04\0\x02\0\x04\x12\x03\x12\x02\n\
+    \x02\0\x12\x03\x12\x02\x1e\n\x0c\n\x05\x04\0\x02\0\x04\x12\x03\x12\x02\n\
     \n\x0c\n\x05\x04\0\x02\0\x06\x12\x03\x12\x0b\x12\n\x0c\n\x05\x04\0\x02\0\
-    \x01\x12\x03\x12\x13\x17\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x12\x1a\x1b\
+    \x01\x12\x03\x12\x13\x19\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x12\x1c\x1d\
     \n\x0b\n\x04\x04\0\x02\x01\x12\x03\x13\x02\x1f\n\x0c\n\x05\x04\0\x02\x01\
     \x04\x12\x03\x13\x02\n\n\x0c\n\x05\x04\0\x02\x01\x06\x12\x03\x13\x0b\x12\
     \n\x0c\n\x05\x04\0\x02\x01\x01\x12\x03\x13\x13\x1a\n\x0c\n\x05\x04\0\x02\

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -387,11 +387,11 @@ impl Report {
         results: Option<&[modsurfer_module::ValType]>,
     ) {
         if let Some(params) = params {
-            let test_params = actual.args == params;
+            let test_params = actual.params == params;
             self.validate_fn(
                 &format!("{name}.params"),
                 format!("{:?}", params),
-                format!("{:?}", actual.args),
+                format!("{:?}", actual.params),
                 test_params,
                 8,
                 Classification::AbiCompatibilty,
@@ -399,11 +399,11 @@ impl Report {
         };
 
         if let Some(results) = results {
-            let test_results = actual.returns == results;
+            let test_results = actual.results == results;
             self.validate_fn(
                 &format!("{name}.results"),
                 format!("{:?}", results),
-                format!("{:?}", actual.returns),
+                format!("{:?}", actual.results),
                 test_results,
                 8,
                 Classification::AbiCompatibilty,
@@ -848,8 +848,8 @@ pub fn generate_checkfile(module: &modsurfer_module::Module) -> Result<Validatio
         include_imports.push(ImportItem::Item {
             namespace: Some(imp.module_name.clone()),
             name: imp.func.name.clone(),
-            params: Some(imp.func.ty.args.clone()),
-            results: Some(imp.func.ty.returns.clone()),
+            params: Some(imp.func.ty.params.clone()),
+            results: Some(imp.func.ty.results.clone()),
         });
     });
     imports.include = Some(include_imports);
@@ -872,8 +872,8 @@ pub fn generate_checkfile(module: &modsurfer_module::Module) -> Result<Validatio
     module.exports.iter().for_each(|exp| {
         include_exports.push(FunctionItem::Item {
             name: exp.func.name.clone(),
-            params: Some(exp.func.ty.args.clone()),
-            results: Some(exp.func.ty.returns.clone()),
+            params: Some(exp.func.ty.params.clone()),
+            results: Some(exp.func.ty.results.clone()),
         });
     });
     let export_count = include_exports.len();


### PR DESCRIPTION
Fixes #17 