### PR TITLE
fix: building modsurfer as wasm

### DIFF
--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -469,6 +469,7 @@ pub struct Module {}
 // this uses Extism's "typed plugin" macro to produce a new struct `ModuleParser`, which contains
 // an associated function `parse_module`. This enables us to wrap the extism::Plugin type and feel
 // more like regular Rust functions vs. the using the generalized `Plugin::call` function.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 extism::typed_plugin!(ModuleParser {
     parse_module(&[u8]) -> Protobuf<ApiModule>;
 });


### PR DESCRIPTION
This only fixes building as `wasm32-unknown-unknown`, major updates need to be done if we need to build this as `wasm32-wasi`. For consistently reasons, `target_os = "unknown"` was specified.